### PR TITLE
Improve monitoring dashboard layout and filtering

### DIFF
--- a/PetersenTestingApp/Components/Pages/MonitoringPage/MonitoringPage.razor
+++ b/PetersenTestingApp/Components/Pages/MonitoringPage/MonitoringPage.razor
@@ -6,7 +6,7 @@
 <h2 class="text-2xl font-semibold mb-4">Pressure Monitoring Dashboard</h2>
 
 <!-- Live Sensor Dashboard -->
-<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-8">
+<div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4 mb-8">
     @foreach (var reading in liveReadings)
     {
         <div class="border rounded-lg shadow p-4 bg-white">

--- a/PetersenTestingApp/Components/Pages/MonitoringPage/MonitoringPage.razor.cs
+++ b/PetersenTestingApp/Components/Pages/MonitoringPage/MonitoringPage.razor.cs
@@ -33,7 +33,26 @@ public partial class MonitoringPage : ComponentBase
 
     protected override async Task OnInitializedAsync()
     {
-        liveReadings = await DashboardBackendService.GetLatestSensorReadingsAsync();
+        var readings = await DashboardBackendService.GetLatestSensorReadingsAsync();
+
+        var cutoff = DateTime.UtcNow.AddHours(-12);
+
+        var recent = readings
+            .Where(r => r.TimeStamp >= cutoff)
+            .OrderByDescending(r => r.TimeStamp)
+            .ToList();
+
+        if (recent.Count < 5)
+        {
+            liveReadings = readings
+                .OrderByDescending(r => r.TimeStamp)
+                .Take(5)
+                .ToList();
+        }
+        else
+        {
+            liveReadings = recent;
+        }
     }
 
     private async Task OnQuerySubmit()


### PR DESCRIPTION
## Summary
- Show sensor cards in a responsive grid with up to five sensors per row
- Filter sensors to those seen in last 12 hours, with fallback to five most recent sensors

## Testing
- `dotnet build PetersenTestingApp.sln` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_b_6893a697cb0c832ca700509ca70fd8e6