### PR TITLE
Improve pressure history plotting UX

### DIFF
--- a/PetersenTestingApp/Components/Monitoring/PressureHistoryPlot.razor
+++ b/PetersenTestingApp/Components/Monitoring/PressureHistoryPlot.razor
@@ -9,11 +9,15 @@
 
 @code {
     [Parameter] public List<SensorReading> Data { get; set; }
+    private List<SensorReading>? _renderedData;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (firstRender && Data?.Any() == true)
+        if (Data?.Any() == true && !ReferenceEquals(Data, _renderedData))
+        {
             await RenderChartAsync();
+            _renderedData = Data;
+        }
     }
 
     private async Task RenderChartAsync()

--- a/PetersenTestingApp/Components/Pages/MonitoringPage/MonitoringPage.razor
+++ b/PetersenTestingApp/Components/Pages/MonitoringPage/MonitoringPage.razor
@@ -29,30 +29,29 @@
     </div>
 
     <!-- Historical Chart Section -->
-    <div class="mt-12 space-y-4">
-        <h2 class="text-2xl font-bold">Historical Pressure Plot</h2>
+    <div class="mt-12 space-y-4 max-w-4xl mx-auto px-4">
+        <h2 class="text-2xl font-bold text-center">Historical Pressure Plot</h2>
 
-        <EditForm Model="query" OnValidSubmit="OnQuerySubmit" class="grid grid-cols-1 sm:grid-cols-4 gap-4 items-end">
-            <div>
-                <label class="block text-sm font-medium text-gray-700">Sensor ID</label>
-                <InputText @bind-Value="query.SensorId" class="form-input mt-1 block w-full" />
+        <EditForm Model="query" OnValidSubmit="OnQuerySubmit" class="flex flex-wrap gap-4 items-end justify-center">
+            <div class="flex items-center gap-2">
+                <label for="sensorId" class="text-sm font-medium text-gray-700">Sensor ID</label>
+                <InputText id="sensorId" @bind-Value="query.SensorId" class="form-input" />
             </div>
-            <div>
-                <label class="block text-sm font-medium text-gray-700">Start Date / Time</label>
-                <input type="datetime-local"
-                       class="form-input mt-1 block w-full"
-                       @bind="query.StartDate" />
+            <div class="flex items-center gap-2">
+                <label for="startDate" class="text-sm font-medium text-gray-700">Start</label>
+                <input id="startDate" type="datetime-local" class="form-input" @bind="query.StartDate" />
             </div>
-            <div>
-                <label class="block text-sm font-medium text-gray-700">End Date / Time</label>
-                <input type="datetime-local"
-                       class="form-input mt-1 block w-full"
-                       @bind="query.EndDate" />
+            <div class="flex items-center gap-2">
+                <label for="endDate" class="text-sm font-medium text-gray-700">End</label>
+                <input id="endDate" type="datetime-local" class="form-input" @bind="query.EndDate" />
             </div>
-            <div>
-                <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded w-full">Plot</button>
-            </div>
+            <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Plot</button>
         </EditForm>
+
+        @if (!string.IsNullOrEmpty(errorMessage))
+        {
+            <p class="text-red-600">@errorMessage</p>
+        }
 
         @if (plotData?.Any() == true)
         {

--- a/PetersenTestingApp/Components/Pages/MonitoringPage/MonitoringPage.razor.cs
+++ b/PetersenTestingApp/Components/Pages/MonitoringPage/MonitoringPage.razor.cs
@@ -11,6 +11,7 @@ public partial class MonitoringPage : ComponentBase
     [Inject] private IJSRuntime JS { get; set; }
     private List<SensorReading> liveReadings = new();
     private List<SensorReading> plotData = new();
+    private string? errorMessage;
 
     private PlotQuery query = new()
     {
@@ -24,12 +25,19 @@ public partial class MonitoringPage : ComponentBase
     }
     private async Task OnQuerySubmit()
     {
+        if (string.IsNullOrWhiteSpace(query.SensorId))
+        {
+            errorMessage = "Please enter a sensor ID.";
+            return;
+        }
+
         plotData = await DashboardBackendService
             .GetSensorReadingsForDateRangeAsync(query.SensorId, query.StartDate, query.EndDate);
 
         if (plotData is null || !plotData.Any())
             return;
 
+        errorMessage = null;
         await InvokeAsync(StateHasChanged); // ensures UI re-renders
     }
 


### PR DESCRIPTION
## Summary
- Warn when plotting without a sensor ID instead of crashing
- Allow replotting by rerendering the chart when parameters change
- Center historical plot section and display filter inputs inline

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6894ce80b64c832c8d0f57391fef1143