### PR TITLE
Improve historical plot layout

### DIFF
--- a/PetersenTestingApp/Components/Monitoring/PressureHistoryPlot.razor
+++ b/PetersenTestingApp/Components/Monitoring/PressureHistoryPlot.razor
@@ -3,7 +3,9 @@
 
 @if (Data?.Any() == true)
 {
-    <canvas id="pressureChart" style="width: 100%; height: 400px;"></canvas>
+    <div class="w-full h-96 bg-white p-4 rounded shadow">
+        <canvas id="pressureChart" class="w-full h-full"></canvas>
+    </div>
 
 }
 
@@ -50,6 +52,7 @@
         var chartOptions = new
         {
             responsive = true,
+            maintainAspectRatio = false,
             plugins = new
             {
                 title = new

--- a/PetersenTestingApp/Components/Pages/MonitoringPage/MonitoringPage.razor
+++ b/PetersenTestingApp/Components/Pages/MonitoringPage/MonitoringPage.razor
@@ -29,23 +29,23 @@
     </div>
 
     <!-- Historical Chart Section -->
-    <div class="mt-12 space-y-4 max-w-4xl mx-auto px-4">
+    <div class="mt-12 space-y-6 w-full px-4">
         <h2 class="text-2xl font-bold text-center">Historical Pressure Plot</h2>
 
-        <EditForm Model="query" OnValidSubmit="OnQuerySubmit" class="flex flex-wrap gap-4 items-end justify-center">
-            <div class="flex items-center gap-2">
+        <EditForm Model="query" OnValidSubmit="OnQuerySubmit" class="flex flex-wrap gap-4 justify-center bg-white p-4 rounded shadow w-full">
+            <div class="flex flex-col p-2">
                 <label for="sensorId" class="text-sm font-medium text-gray-700">Sensor ID</label>
-                <InputText id="sensorId" @bind-Value="query.SensorId" class="form-input" />
+                <InputText id="sensorId" @bind-Value="query.SensorId" class="form-input mt-1 p-2 rounded" />
             </div>
-            <div class="flex items-center gap-2">
+            <div class="flex flex-col p-2">
                 <label for="startDate" class="text-sm font-medium text-gray-700">Start</label>
-                <input id="startDate" type="datetime-local" class="form-input" @bind="query.StartDate" />
+                <input id="startDate" type="datetime-local" class="form-input mt-1 p-2 rounded" @bind="query.StartDate" />
             </div>
-            <div class="flex items-center gap-2">
+            <div class="flex flex-col p-2">
                 <label for="endDate" class="text-sm font-medium text-gray-700">End</label>
-                <input id="endDate" type="datetime-local" class="form-input" @bind="query.EndDate" />
+                <input id="endDate" type="datetime-local" class="form-input mt-1 p-2 rounded" @bind="query.EndDate" />
             </div>
-            <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Plot</button>
+            <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded shadow">Plot</button>
         </EditForm>
 
         @if (!string.IsNullOrEmpty(errorMessage))


### PR DESCRIPTION
## Summary
- restyle historical query form with padding and stacked labels
- wrap pressure chart in card element and disable aspect ratio for responsive sizing

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... 403 Forbidden)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_6894d14a52f8832cbd5b3e8456f4d6f2